### PR TITLE
Rename Checkout Command to Clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,24 +15,25 @@ Tests are run in the Beaker test-suite.
 Command overview:
 
 ```bash
+
 Usage: bkr <command> [opts...]
 
 Publishing:
 
   init [directory] - create a new dat
+  fork <dat-url|directory> [directory] - create a new dat by copying
   status [directory] - check the change status of a dat
   publish [directory] - publish a new version of a dat
 
-Checkouts:
+Fetching:
 
-  co <dat-url> [directory] - checkout a dat
-  fork <dat-url|directory> [directory] - fork and then checkout a dat
+  clone <dat-url> [directory] - copy a dat into a dir
   pull [--live] [directory] - pull the latest version of a dat
 
 Open in beaker:
 
   open [directory] - open the dat in a folder
-  dev [directory] - create and open a temporary live-watching dat (useful for dev)
+  dev [directory] - create and open a temporary live-watching dat
 
 Management:
 
@@ -69,6 +70,7 @@ When working, use `bkr dev` to create a temporary live-watching site.
 (The site is temporary so that your in-progress changes dont get published out into the network.)
 
 ```bash
+$ bkr clone dat://0ff7d4c7644d0aa19914247dc5dbf502d6a02ea89a5145e7b178d57db00504cd/ ~/my-site
 $ cd ~/my-site
 $ bkr dev 
 
@@ -123,10 +125,10 @@ Effects:
  - The new site is hosted on the network.
  - A dat.json manifest file is created in the directory.
 
-### Checkout
+### Clone
 
 ```
-bkr co <dat-url> [directory]
+bkr clone <dat-url> [directory]
 ```
 
 Check out a copy of a dat site into the given directory.
@@ -142,7 +144,7 @@ bkr fork <dat-url|directory> [directory]
 ```
 
 Create a new dat site, using the given dat-url or directory as a template.
-This is similar to running `bkr co`, deleting the `dat.json`, then running `bkr init`.
+This is similar to running `bkr clone`, deleting the `dat.json`, then running `bkr init`.
 
 If no second directory is given, it will use the current directory.
 You can fork a checked-out dat site in place by running `bkr fork .`.

--- a/bin/bkr.js
+++ b/bin/bkr.js
@@ -5,7 +5,7 @@ import chalk from 'chalk'
 import semver from 'semver'
 
 import initCmd from '../lib/commands/init'
-import coCmd from '../lib/commands/co'
+import cloneCmd from '../lib/commands/clone'
 import forkCmd from '../lib/commands/fork'
 import statusCmd from '../lib/commands/status'
 import openCmd from '../lib/commands/open'
@@ -30,7 +30,7 @@ const MIN_BEAKER_VERSION = '0.5.0'
 
 var commands = [
   initCmd,
-  coCmd,
+  cloneCmd,
   forkCmd,
   statusCmd,
   openCmd,

--- a/lib/commands/clone.js
+++ b/lib/commands/clone.js
@@ -9,7 +9,7 @@ import { isDirClean, getDatManifest, writeDatManifest } from '../working-dir'
 import { trim, normalizeUrl } from '../strings'
 
 export default {
-  name: 'co',
+  name: 'clone',
   command: async function (args) {
     var rpc = getClient()
     var daturl = daturlOpt(args._[0])

--- a/lib/commands/co.js
+++ b/lib/commands/co.js
@@ -6,7 +6,7 @@ import mkdirp from 'mkdirp'
 import { getClient } from '../client'
 import { daturlOpt, dirOpt, daturlToKey } from '../opts'
 import { isDirClean, getDatManifest, writeDatManifest } from '../working-dir'
-import { trim } from '../strings'
+import { trim, normalizeUrl } from '../strings'
 
 export default {
   name: 'co',
@@ -39,7 +39,7 @@ export default {
       manifest = { url: daturl }
       shouldWriteManifest = true
     }
-    if (manifest.url !== daturl) {
+    if (normalizeUrl(manifest.url) !== normalizeUrl(daturl)) {
       // the url field needs to be set
       manifest.url = daturl
       console.log(`dat.json url field is incorrect, updating.`)

--- a/lib/strings.js
+++ b/lib/strings.js
@@ -32,3 +32,7 @@ export function niceDate (ts, opts) {
     return ts.fromNow()
   return ts.format("ll")
 }
+
+export function normalizeUrl (url) {
+  return url.replace(/(\/)*$/, '') // strip trailing slash
+}

--- a/lib/usage.js
+++ b/lib/usage.js
@@ -11,19 +11,19 @@ export default function usage (err) {
 ${chalk.bold(`Publishing:`)}
 
   ${chalk.bold(`init`)} ${chalk.gray(`[directory]`)} - create a new dat
+  ${chalk.bold(`fork`)} <dat-url|directory> ${chalk.gray(`[directory]`)} - create a new dat by copying
   ${chalk.bold(`status`)} ${chalk.gray(`[directory]`)} - check the change status of a dat
   ${chalk.bold(`publish`)} ${chalk.gray(`[directory]`)} - publish a new version of a dat
 
-${chalk.bold(`Checkouts:`)}
+${chalk.bold(`Fetching:`)}
 
-  ${chalk.bold(`co`)} <dat-url> ${chalk.gray(`[directory]`)} - checkout a dat
-  ${chalk.bold(`fork`)} <dat-url|directory> ${chalk.gray(`[directory]`)} - fork and then checkout a dat
+  ${chalk.bold(`clone`)} <dat-url> ${chalk.gray(`[directory]`)} - copy a dat into a dir
   ${chalk.bold(`pull`)} ${chalk.gray(`[--live] [directory]`)} - pull the latest version of a dat
 
 ${chalk.bold(`Open in beaker:`)}
 
   ${chalk.bold(`open`)} ${chalk.gray(`[directory]`)} - open the dat in a folder
-  ${chalk.bold(`dev`)} ${chalk.gray(`[directory]`)} - create and open a temporary live-watching dat (useful for dev)
+  ${chalk.bold(`dev`)} ${chalk.gray(`[directory]`)} - create and open a temporary live-watching dat
 
 ${chalk.bold(`Management:`)}
 


### PR DESCRIPTION
Sorry to the interface change, all.

The dat project ended up using the term 'clone', so I want to mimic them on that.